### PR TITLE
update test_sensor.py according api 20210118 changes

### DIFF
--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -279,7 +279,7 @@ class TestTempSensor(DefaultBoxTest):
 class TestAirSensor(DefaultBoxTest):
     """Tests for sensors representing BleBox airSensor."""
 
-    DEV_INFO_PATH = "api/air/state"
+    DEV_INFO_PATH = "state"
 
     DEVCLASS = "sensors"
     ENTITY_CLASS = BleBoxSensorEntity
@@ -287,12 +287,13 @@ class TestAirSensor(DefaultBoxTest):
     DEVICE_INFO = json.loads(
         """
     {
-        "deviceName": "My air 1",
+        "deviceName": "airSensor",
         "type": "airSensor",
-        "fv": "0.973",
-        "hv": "0.6",
-        "apiLevel": "20180403",
-        "id": "1afe34db9437",
+        "product": "airSensor",
+        "fv": "0.1007",
+        "hv": "1.6",
+        "apiLevel": "20210118",
+        "id": "0af9e06b71d4",
         "ip": "192.168.1.11"
     }
     """
@@ -327,14 +328,15 @@ class TestAirSensor(DefaultBoxTest):
         """
         {
             "air": {
+                "airQualityLevel": 6,
                 "sensors": [
                     {
                         "type": "pm1",
                         "value": 49,
                         "trend": 3,
                         "state": 0,
-                        "qualityLevel": 0,
-                        "elaspedTimeS": -1
+                        "qualityLevel": -1,
+                        "elapsedTimeS": -1
                     },
                     {
                         "type": "pm2.5",
@@ -342,7 +344,7 @@ class TestAirSensor(DefaultBoxTest):
                         "trend": 1,
                         "state": 0,
                         "qualityLevel": 4,
-                        "elaspedTimeS": -1
+                        "elapsedTimeS": -1
                     },
                     {
                         "type": "pm10",
@@ -350,7 +352,7 @@ class TestAirSensor(DefaultBoxTest):
                         "trend": 0,
                         "state": 0,
                         "qualityLevel": 6,
-                        "elaspedTimeS": -1
+                        "elapsedTimeS": -1
                     }
                 ]
             }
@@ -358,8 +360,8 @@ class TestAirSensor(DefaultBoxTest):
         """
     )
 
-    # DEVICE_EXTENDED_INFO
-    # DEVICE_EXTENDED_INFO_PATH
+    DEVICE_EXTENDED_INFO = DEVICE_INFO
+    DEVICE_EXTENDED_INFO_PATH = 'info'
 
     async def test_init(self, aioclient_mock):
         """Test air quality sensor default state."""


### PR DESCRIPTION
Changes to test unit wit latest api (20210118):
- new info endpoint (just /info)
- new status endpoint (just /status)
- overall airQualityLevel field
- fixed typo in api for sensors (from elaspedTimeS to elapsedTimeS)